### PR TITLE
[Feature]: Desktop用のProfile画面を作成

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/App.kt
@@ -34,4 +34,4 @@ enum class DeviceType {
     Mobile, Desktop
 }
 
-val MobileWidth = 600.dp
+val MobileWidth = 800.dp

--- a/composeApp/src/commonMain/kotlin/org/example/project/ui/feature/profile/ProfileDesktopContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/ui/feature/profile/ProfileDesktopContent.kt
@@ -1,16 +1,25 @@
 package org.example.project.ui.feature.profile
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.example.project.ui.feature.profile.component.BasicInfoSection
+import org.example.project.ui.feature.profile.component.Footer
+import org.example.project.ui.feature.profile.component.SNSSection
+import org.example.project.ui.feature.profile.component.SkillsSection
+import org.example.project.ui.feature.profile.component.WorksSection
 import org.example.project.ui.theme.dimensions.Paddings
+import org.example.project.ui.theme.dimensions.Weights
 
 @Composable
 fun ProfileDesktopContent(
@@ -20,17 +29,47 @@ fun ProfileDesktopContent(
         modifier = modifier,
         color = MaterialTheme.colorScheme.surface,
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
         ) {
-            Column(
-                modifier = Modifier.fillMaxSize()
-                    .padding(Paddings.Content),
-            ) {
-                BasicInfoSection(
-                    modifier = Modifier.fillMaxWidth(),
+            Row {
+                Spacer(
+                    modifier = Modifier.weight(Weights.Medium),
+                )
+                Column(
+                    modifier = Modifier
+                        .weight(Weights.Large)
+                        .padding(vertical = Paddings.Content),
+                    verticalArrangement = Arrangement.spacedBy(Paddings.Large),
+                ) {
+                    BasicInfoSection(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Paddings.Content),
+                    )
+                    WorksSection(
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    SkillsSection(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Paddings.Content),
+                    )
+                    SNSSection(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Paddings.Content),
+                    )
+                }
+                Spacer(
+                    modifier = Modifier.weight(Weights.Medium),
                 )
             }
+            Footer(
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/ui/theme/dimensions/Weights.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/ui/theme/dimensions/Weights.kt
@@ -4,4 +4,5 @@ package org.example.project.ui.theme.dimensions
 
 data object Weights {
     const val Medium = 1f
+    const val Large = 2f
 }


### PR DESCRIPTION
## 概要
PC用のProfile画面の作成を行った。
Mobile用のProfile画面との変更点は、左右の余白がどれだけあるかという変更だけである。
上で述べた通り、Mobile用のProfile画面との差異が殆ど無いため、PC専用のデザインを今後作っていく必要があるとは思うが、一旦はこれで終了とする。

## 実施Issue
#13 

<!-- UIに変更があった際に使用 -->
## UI変更
| After |
|-------|
| <img src="https://github.com/user-attachments/assets/aed40ebe-1c72-455e-9902-dce1d3a3e3a4" width="600" /> |
